### PR TITLE
feat: update react peer dependencies to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "three-stdlib": "^2.17.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0",
     "three": "^0.132.2"
   },
   "main": "lib/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14180,8 +14180,8 @@ __metadata:
     ts-jest: ^28.0.5
     typescript: ^4.7.3
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ^17.0.2 || ^18.0.0
+    react-dom: ^17.0.2 || ^18.0.0
     three: ^0.132.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR includes `yarn.lock` as well.

Set matching versions with `^18.0.0` cause anyway it's going to match all versions starting with 18. 