### PR TITLE
Add the possibility to process the model's geometry

### DIFF
--- a/.storybook/stories/FromUrl.stories.tsx
+++ b/.storybook/stories/FromUrl.stories.tsx
@@ -46,7 +46,8 @@ function FromUrl(props: Omit<StlViewerProps, "url">) {
                     rotationZ,
                     scale: 1,
                     color: "#008675",
-                    ref
+                    ref,
+                    geometryProcessor: geometry => geometry
                 }}
                 floorProps={{
                     gridWidth: 300

--- a/README.md
+++ b/README.md
@@ -70,16 +70,17 @@ The component also accepts ```<div/>``` props
 
 ### ModelProps
 
-| Prop                       | Type                       | Required     | Notes                                                                                                                                                                                       |
-| ----------------------     | :------------------------: | :----------: | :----------------------------------------------------------:                                                                                                                                |
-| `ref`                      | `{current: ModelRef}`      | `false`      | reference of the 3d model for accessing it's properties |
-| `scale`                    | `number`                   | `false`      | scale of the 3d model, defaults to 1 |
-| `positionX`                | `number`                   | `false`      | x coordinate in the world of the 3d model |
-| `positionY`                | `number`                   | `false`      | y coordinate in the world of the 3d model |
-| `rotationX`                | `number`                   | `false`      | rotation in x axis of the model |
-| `rotationY`                | `number`                   | `false`      | rotation in y axis of the model |
-| `rotationY`                | `number`                   | `false`      | rotation in z axis of the model |
-| `color`                    | `CSSProperties['color']`   | `false`      | color of the 3d model, defaults to "grey" |
+| Prop            |                      Type                      | Required |                          Notes                          |
+|-----------------|:----------------------------------------------:|:--------:|:-------------------------------------------------------:|
+| `ref`           |             `{current: ModelRef}`              | `false`  | reference of the 3d model for accessing it's properties |
+| `scale`         |                    `number`                    | `false`  |          scale of the 3d model, defaults to 1           |
+| `positionX`     |                    `number`                    | `false`  |        x coordinate in the world of the 3d model        |
+| `positionY`     |                    `number`                    | `false`  |        y coordinate in the world of the 3d model        |
+| `rotationX`     |                    `number`                    | `false`  |             rotation in x axis of the model             |
+| `rotationY`     |                    `number`                    | `false`  |             rotation in y axis of the model             |
+| `rotationY`     |                    `number`                    | `false`  |             rotation in z axis of the model             |
+| `color`         |            `CSSProperties['color']`            | `false`  |        color of the 3d model, defaults to "grey"        |
+| `geometryProps` | `(geometry: BufferGeometry) => BufferGeometry` | `false`  |     Perform some processing to the models geometry      | 
 
 ### FloorProps
 | Prop                       | Type                       | Required     | Notes                                                                                                                                                                                       |

--- a/src/StlViewer/SceneSetup.tsx
+++ b/src/StlViewer/SceneSetup.tsx
@@ -1,7 +1,7 @@
-import React, { CSSProperties, useEffect, useState } from 'react'
+import React, { CSSProperties, useEffect, useMemo, useState } from 'react'
 import { useFrame, useLoader } from '@react-three/fiber'
 import { STLLoader } from 'three-stdlib/loaders/STLLoader'
-import { Box3, Color, Group, Mesh } from 'three'
+import { Box3, BufferGeometry, Color, Group, Mesh } from 'three'
 import { STLExporter } from './exporters/STLExporter'
 import Model3D, { ModelDimensions } from './SceneElements/Model3D'
 import Floor from './SceneElements/Floor'
@@ -35,6 +35,7 @@ export interface ModelProps {
   rotationY?: number
   rotationZ?: number
   color?: CSSProperties['color']
+  geometryProcessor?: (geometry: BufferGeometry) => BufferGeometry
 }
 
 export interface SceneSetupProps {
@@ -64,7 +65,8 @@ const SceneSetup: React.FC<SceneSetupProps> = (
       rotationX = 0,
       rotationY = 0,
       rotationZ = 0,
-      color = 'grey'
+      color = 'grey',
+      geometryProcessor
     } = {},
     floorProps: {
       gridWidth,
@@ -93,6 +95,11 @@ const SceneSetup: React.FC<SceneSetupProps> = (
     STLLoader,
     url,
     (loader) => loader.setRequestHeader(extraHeaders ?? {})
+  )
+
+  const processedGeometry = useMemo(
+    () => geometryProcessor?.(geometry) ?? geometry,
+    [geometry, geometryProcessor]
   )
 
   function onLoaded (dims: ModelDimensions, mesh: Mesh): void {
@@ -150,7 +157,7 @@ const SceneSetup: React.FC<SceneSetupProps> = (
                 name={'group'}
                 meshProps={{ name: 'mesh' }}
                 scale={scale}
-                geometry={geometry}
+                geometry={processedGeometry}
                 position={modelPosition}
                 rotation={[rotationX, rotationY, rotationZ]}
                 visible={sceneReady}


### PR DESCRIPTION
As an alternative to https://github.com/gabotechs/react-stl-viewer/pull/37, let the users perform an arbitrary post-processing to the loaded geometry.

The post-processing callback is just one more parameter in the `ModelProps`, and it can be used like this:
```tsx
<StlViewer
  modelProps={{
     geometryProcessor: (geometry) => LoopSubdivision.modify(geometry, 3, { })
  }}
/>
```