### PR TITLE
feat: add model prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can see working the examples from `.storybook/stories` [here](https://gabote
 | Prop              |              Type              | Required |                            Notes                            |
 |-------------------|:------------------------------:|:--------:|:-----------------------------------------------------------:|
 | `url`             |            `string`            |  `true`  |                     url of the Stl file                     |
+| `model`           |   `string` or `ArrayBuffer`    | `false`  |             raw stl data, takes priority over `url`         |
 | `cameraProps`     |         `CameraProps`          | `false`  |                camera properties, see below                 |
 | `modelProps`      |          `ModelProps`          | `false`  |               3d model properties, see below                |
 | `floorProps`      |          `FloorProps`          | `false`  |                 floor properties, see below                 |

--- a/src/StlViewer/SceneSetup.tsx
+++ b/src/StlViewer/SceneSetup.tsx
@@ -1,6 +1,5 @@
 import React, { CSSProperties, useEffect, useMemo, useState } from 'react'
-import { useFrame, useLoader, useThree } from '@react-three/fiber'
-import { STLLoader } from 'three-stdlib/loaders/STLLoader'
+import { useFrame, useThree } from '@react-three/fiber'
 import { Box3, BufferGeometry, Color, Group, Mesh } from 'three'
 import { STLExporter } from './exporters/STLExporter'
 import Model3D, { ModelDimensions } from './SceneElements/Model3D'
@@ -8,6 +7,7 @@ import Floor from './SceneElements/Floor'
 import Lights from './SceneElements/Lights'
 import Camera, { CameraPosition, polarToCartesian } from './SceneElements/Camera'
 import OrbitControls from './SceneElements/OrbitControls'
+import { useGeometry } from './useGeometry'
 
 const INITIAL_LATITUDE = Math.PI / 8
 const INITIAL_LONGITUDE = -Math.PI / 8
@@ -49,6 +49,7 @@ export interface ModelProps {
 
 export interface SceneSetupProps {
   url: string
+  model: ArrayBuffer | string | undefined
   /** @deprecated use cameraProps.initialPosition instead */
   cameraInitialPosition?: Partial<CameraPosition>
   extraHeaders?: Record<string, string>
@@ -64,6 +65,7 @@ export interface SceneSetupProps {
 const SceneSetup: React.FC<SceneSetupProps> = (
   {
     url,
+    model,
     extraHeaders,
     shadows = false,
     showAxes = false,
@@ -115,13 +117,9 @@ const SceneSetup: React.FC<SceneSetupProps> = (
   const [sceneReady, setSceneReady] = useState(false)
   useEffect(() => {
     setSceneReady(false)
-  }, [url])
+  }, [url, model])
 
-  const geometry = useLoader(
-    STLLoader,
-    url,
-    (loader) => loader.setRequestHeader(extraHeaders ?? {})
-  )
+  const geometry = useGeometry(url, model, extraHeaders)
 
   const processedGeometry = useMemo(
     () => geometryProcessor?.(geometry) ?? geometry,

--- a/src/StlViewer/StlViewer.tsx
+++ b/src/StlViewer/StlViewer.tsx
@@ -14,6 +14,7 @@ export interface StlViewerProps extends DivProps, SceneSetupProps {
 const StlViewer: React.FC<StlViewerProps> = (
   {
     url,
+    model,
     cameraProps,
     modelProps,
     floorProps,
@@ -31,6 +32,7 @@ const StlViewer: React.FC<StlViewerProps> = (
 ) => {
   const sceneProps: SceneSetupProps = {
     url,
+    model,
     cameraProps,
     modelProps,
     floorProps,

--- a/src/StlViewer/useGeometry.tsx
+++ b/src/StlViewer/useGeometry.tsx
@@ -1,0 +1,21 @@
+import { STLLoader } from 'three-stdlib/loaders/STLLoader'
+import { useLoader } from '@react-three/fiber'
+import { useMemo } from 'react'
+import { BufferGeometry, NormalBufferAttributes } from 'three'
+
+export const useGeometry = (
+  url: string,
+  model: string | ArrayBuffer | undefined,
+  extraHeaders: Record<string, string> | undefined
+): BufferGeometry<NormalBufferAttributes> => {
+  const geometry = useMemo(() => {
+    if (model !== undefined) {
+      return new STLLoader().parse(model)
+    } else {
+      return useLoader(STLLoader, url, (loader) => {
+        loader.setRequestHeader(extraHeaders ?? {})
+      })
+    }
+  }, [model, url, extraHeaders])
+  return geometry
+}


### PR DESCRIPTION
allow to pass a STL model directly via a prop. this makes
it possible to generate STL models within an application
or more obtain it through more complex API calls